### PR TITLE
docs: add Tier 1 web ops workflow + repo analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # Test
 Bootstrap website for Doable Group
+
+## Web Ops Documentation
+
+- `docs/WEB_OPS_WORKFLOW_TIER1.md`
+- `docs/REPO_ANALYSIS_2026-03-19.md`

--- a/docs/REPO_ANALYSIS_2026-03-19.md
+++ b/docs/REPO_ANALYSIS_2026-03-19.md
@@ -1,0 +1,20 @@
+# Repo Analysis — 2026-03-19
+
+Repository: `DOAbleLLC/web`
+
+## Summary
+- Stack appears static HTML/CSS/JS (non-Jekyll)
+- Front-door pages and service pages are directly editable HTML files
+- Suitable for controlled PR-based content/structure updates
+
+## Observations
+- Documentation baseline is minimal (`README.md` short)
+- Strong candidate for explicit workflow docs and PR checklist discipline
+
+## Recommended Next Improvements
+1. Add lightweight PR template for website changes
+2. Add QA preview process note in repo docs
+3. Add deploy verification checklist reference
+
+## This PR
+- Adds Tier 1 workflow doc and repo analysis note under `docs/`

--- a/docs/WEB_OPS_WORKFLOW_TIER1.md
+++ b/docs/WEB_OPS_WORKFLOW_TIER1.md
@@ -1,0 +1,28 @@
+# Web Ops Workflow (Tier 1: doablegroup.com)
+
+## Scope
+- In scope: `doablegroup.com` front-door website (repo: `DOAbleLLC/web`)
+- Out of scope: brand sub-sites and campaign microsites unless explicitly activated
+
+## Cadence
+- Monday 11:00 ET: research scan
+- Thursday 15:00 ET: delta scan
+- Tuesday/Friday: web execution windows
+- Friday 17:00 ET: impact review
+
+## Approval Gates
+1. Director approves recommendation packet
+2. Director approves QA preview URL (mandatory for non-hotfix)
+3. Director approves production deploy
+
+## Required Artifacts
+- Recommendation packet
+- Change queue entry
+- PR checklist
+- QA preview URL + notes
+- Post-deploy verification
+
+## Control Rules
+- Mode A approval policy enforced
+- No production deploy without explicit Director approval
+- Credential access is task-scoped and time-bounded


### PR DESCRIPTION
## Summary\n- add Tier 1 website ops workflow documentation for doablegroup.com\n- add repo analysis note for current baseline\n- link both docs from README\n\n## Why\nAligns the front-door repo () with the approved Research -> QA Preview -> Production governance flow.\n\n## Risk\nLow (docs-only changes).\n