### PR TITLE
docs: align README title to Doable Group front-door branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# Test
-Bootstrap website for Doable Group
+# Doable Group — Front Door Website
+
+Official front-door website repository for Doable Group (`doablegroup.com`).
 
 ## Web Ops Documentation
 


### PR DESCRIPTION
Follow-up PR to correct README title/intro on main.\n\n- replace generic title with brand-aligned front-door title\n- clarify repository purpose for doablegroup.com\n\nLow risk: docs-only change.