### PR TITLE
feat: add careers page with internship light state

### DIFF
--- a/about.html
+++ b/about.html
@@ -113,12 +113,8 @@
 
                                     <ul class="navigation right-nav clearfix">
                                         <li class="current"><a href="about.html" tabindex="4">About</a></li>
-                                        <!-- <li class="dropdown"><a href="#">Services</a>
-                                            <ul>
-                                                <li><a href="services.html">Our Services</a></li>
-                                            </ul>
-                                        </li> -->
-                                        <li><a href="contact.html" tabindex="5">Contact</a></li>
+                                        <li><a href="careers.html" tabindex="5">Careers</a></li>
+                                        <li><a href="contact.html" tabindex="6">Contact</a></li>
                                     </ul>
 
                                 </div>
@@ -354,7 +350,7 @@
                 <!-- </div> -->
 
                 <!-- <div class="button-box text-center wow fadeInUp mt-20px " data-wow-delay="0ms " data-wow-duration="1500ms ">
-                    <a href="mailto:career@doablegroup.com" class="theme-btn btn-style-three "><span class="txt ">Join Our Team</span></a>
+                    <a href="mailto:careers@doablegroup.com?subject=Careers%20Inquiry" class="theme-btn btn-style-three "><span class="txt ">Join Our Team</span></a>
                 </div> -->
 
             <!-- </div>

--- a/careers.html
+++ b/careers.html
@@ -1,0 +1,443 @@
+<!DOCTYPE html>
+<html lang="en-US">
+
+<head>
+    <meta charset="UTF-8">
+    <title>Careers at Doable Group | Technology, Design, Operations & Internships</title>
+    <meta name="description" content="Explore careers and internship pathways at Doable Group across technology, design, operations, media, and emerging AI-native work. Reach out with your resume and cover letter." />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="profile" href="https://gmpg.org/xfn/11">
+    <meta name="author" content="psychobit">
+    <link rel="canonical" href="https://www.doablegroup.com/careers" />
+
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Careers at Doable Group | Technology, Design, Operations & Internships" />
+    <meta property="og:url" content="https://www.doablegroup.com/careers" />
+    <meta property="og:site_name" content="Doable Group" />
+    <meta property="og:image" content="/assets/images/resource/doable-group-high-resolution-color-logo.png" />
+    <meta property="og:description" content="Careers at Doable Group — technology, design, operations, and emerging internship opportunities." />
+
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&family=Karla:ital,wght@0,400;0,700;1,700&display=swap" rel="stylesheet">
+
+    <link rel="shortcut icon" href="assets/images/favicon/favicon.png" type="image/x-icon">
+    <link rel="icon" href="assets/images/favicon/favicon.png" type="image/x-icon">
+    <meta name="msapplication-TileImage" content="assets/images/favicon/favicon.png" />
+
+    <script type="application/ld+json">
+        {
+            "@context": "http://schema.org",
+            "@type": "WebPage",
+            "name": "Careers at Doable Group",
+            "url": "https://www.doablegroup.com/careers"
+        }
+    </script>
+
+    <link rel="stylesheet" href="assets/css/vendor/bootstrap.min.css" />
+    <link rel="stylesheet" href="assets/css/vendor/elegenticon.css" />
+    <link rel="stylesheet" href="assets/css/vendor/flaticon.css" />
+    <link rel="stylesheet" href="assets/css/vendor/linearicons.css" />
+    <link rel="stylesheet" href="assets/css/vendor/simple-line-icons.css" />
+    <link rel="stylesheet" href="assets/css/vendor/icofont.min.css" />
+
+    <link rel="stylesheet" href="assets/css/plugins/animate.css" />
+    <link rel="stylesheet" href="assets/css/plugins/animation.css" />
+    <link rel="stylesheet" href="assets/css/plugins/jquery.fancybox.min.css" />
+    <link rel="stylesheet" href="assets/css/plugins/jquery.mCustomScrollbar.min.css" />
+    <link rel="stylesheet" href="assets/css/plugins/owl.css" />
+
+    <link rel="stylesheet" href="assets/css/style.css" />
+    <link rel="stylesheet" href="assets/css/responsive.css" />
+
+    <style>
+        .career-card,
+        .career-cta-box,
+        .career-empty-state {
+            background: #ffffff;
+            border-radius: 12px;
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.06);
+        }
+
+        .career-card {
+            padding: 35px 28px;
+            height: 100%;
+            margin-bottom: 30px;
+        }
+
+        .career-card h4,
+        .career-cta-box h3,
+        .career-empty-state h3 {
+            margin-bottom: 16px;
+        }
+
+        .career-card p,
+        .career-empty-state p,
+        .career-cta-box p,
+        .career-card ul li {
+            color: #666;
+            line-height: 1.8em;
+        }
+
+        .career-card ul {
+            padding-left: 18px;
+            margin-bottom: 0;
+        }
+
+        .career-card .eyebrow,
+        .career-empty-state .eyebrow {
+            display: inline-block;
+            margin-bottom: 12px;
+            color: #7300ff;
+            font-size: 13px;
+            font-weight: 700;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+        }
+
+        .career-empty-state,
+        .career-cta-box {
+            padding: 45px 38px;
+        }
+
+        .career-pill {
+            display: inline-block;
+            padding: 8px 14px;
+            border-radius: 999px;
+            background: rgba(115, 0, 255, 0.08);
+            color: #7300ff;
+            font-size: 13px;
+            font-weight: 700;
+            margin: 0 10px 10px 0;
+        }
+
+        .career-coming-soon {
+            color: #7300ff;
+            font-weight: 700;
+        }
+
+        .career-hero-copy {
+            max-width: 760px;
+            margin: 0 auto;
+            text-align: center;
+        }
+
+        .career-hero-copy p {
+            color: #666;
+            font-size: 18px;
+            line-height: 1.8em;
+        }
+
+        .career-button-row {
+            margin-top: 30px;
+        }
+
+        .career-button-row .theme-btn {
+            margin: 0 10px 12px;
+        }
+
+        .career-note {
+            font-size: 15px;
+            color: #666;
+            margin-top: 18px;
+        }
+    </style>
+</head>
+
+<body>
+
+    <div class="page-wrapper">
+
+        <header class="main-header header-style-two">
+            <div class="header-upper">
+                <div class="auto-container">
+                    <div class="clearfix">
+
+                        <div class="pull-left logo-box">
+                            <div class="logo">
+                                <a href="index.html" id="logo-link">
+                                    <img src="assets/images/logo/logo-2.png" alt="Doable group logo" title="" id="logo-image">
+                                </a>
+                            </div>
+                        </div>
+
+                        <div class="nav-outer clearfix">
+                            <div class="mobile-nav-toggler"><span class="icon flaticon-menu"></span></div>
+                            <nav class="main-menu navbar-expand-md">
+                                <div class="navbar-header">
+                                    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                                        <span class="icon-bar"></span>
+                                        <span class="icon-bar"></span>
+                                        <span class="icon-bar"></span>
+                                    </button>
+                                </div>
+
+                                <div class="navbar-collapse show collapse clearfix" id="navbarSupportedContent">
+                                    <ul class="navigation left-nav clearfix">
+                                        <li><a href="portfolio.html">Studio</a></li>
+                                        <li><a href="services.html">Services</a></li>
+                                    </ul>
+
+                                    <ul class="navigation right-nav clearfix">
+                                        <li><a href="about.html">About</a></li>
+                                        <li class="current"><a href="careers.html">Careers</a></li>
+                                        <li><a href="contact.html">Contact</a></li>
+                                    </ul>
+                                </div>
+                            </nav>
+                        </div>
+
+                    </div>
+                </div>
+            </div>
+
+            <div class="mobile-menu">
+                <div class="menu-backdrop"></div>
+                <div class="close-btn"><span class="icon lnr lnr-cross"></span></div>
+
+                <nav class="menu-box">
+                    <div class="nav-logo">
+                        <a href="index.html"><img src="assets/images/logo/logo-2.png" alt="Doable group logo" title=""></a>
+                    </div>
+                    <div class="menu-outer"></div>
+                </nav>
+            </div>
+        </header>
+
+        <section class="page-title-two-section">
+            <div class="auto-container">
+                <h1>Careers</h1>
+                <ul class="page-breadcrumb">
+                    <li><a href="index.html">Home</a></li>
+                    <li>Careers</li>
+                </ul>
+            </div>
+        </section>
+
+        <section class="about-section">
+            <div class="auto-container">
+                <div class="career-hero-copy wow fadeInUp" data-wow-delay="0ms" data-wow-duration="1500ms">
+                    <h2>Grow with Doable Group</h2>
+                    <p>We’re building across technology, media, design, operations, and modern workflow systems — and we welcome thoughtful people who want to grow with meaningful work.</p>
+                    <div class="career-button-row">
+                        <a href="mailto:careers@doablegroup.com?subject=Careers%20Inquiry" class="theme-btn btn-style-one"><span class="txt">Email careers@doablegroup.com</span></a>
+                        <a href="#opportunity-areas" class="theme-btn btn-style-three"><span class="txt">Explore opportunity areas</span></a>
+                    </div>
+                    <p class="career-note">When reaching out, please include your resume, cover letter, and any relevant portfolio or work samples.</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="services-page-section background-color-gray" id="opportunity-areas">
+            <div class="auto-container">
+                <div class="sec-title centered">
+                    <h2>Opportunity Areas</h2>
+                    <div class="text">Doable Group is growing intentionally. We may not list every opportunity here yet, but these are the kinds of work we are building toward.</div>
+                </div>
+
+                <div class="row clearfix">
+                    <div class="col-lg-6 col-md-6 col-sm-12">
+                        <div class="career-card wow fadeInUp" data-wow-delay="0ms" data-wow-duration="1500ms">
+                            <span class="eyebrow">Software & Product</span>
+                            <h4>Build digital experiences and support product execution</h4>
+                            <ul>
+                                <li>Frontend development</li>
+                                <li>Web and product implementation</li>
+                                <li>QA and technical coordination</li>
+                                <li>Prototype and product support</li>
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="col-lg-6 col-md-6 col-sm-12">
+                        <div class="career-card wow fadeInUp" data-wow-delay="100ms" data-wow-duration="1500ms">
+                            <span class="eyebrow">Design & Creative</span>
+                            <h4>Support brands, interfaces, and creative production</h4>
+                            <ul>
+                                <li>Graphic design</li>
+                                <li>Brand and identity support</li>
+                                <li>UX/UI design</li>
+                                <li>Creative production and asset development</li>
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="col-lg-6 col-md-6 col-sm-12">
+                        <div class="career-card wow fadeInUp" data-wow-delay="0ms" data-wow-duration="1500ms">
+                            <span class="eyebrow">Marketing & Media</span>
+                            <h4>Help shape stories, content, and growth efforts</h4>
+                            <ul>
+                                <li>Marketing and content support</li>
+                                <li>Digital media and audience research</li>
+                                <li>Brand storytelling</li>
+                                <li>Campaign and content coordination</li>
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="col-lg-6 col-md-6 col-sm-12">
+                        <div class="career-card wow fadeInUp" data-wow-delay="100ms" data-wow-duration="1500ms">
+                            <span class="eyebrow">Operations & Admin</span>
+                            <h4>Contribute to coordination, systems, and day-to-day execution</h4>
+                            <ul>
+                                <li>Operations support</li>
+                                <li>Administrative assistance</li>
+                                <li>Business coordination</li>
+                                <li>Workflow and documentation support</li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="about-section">
+            <div class="auto-container">
+                <div class="sec-title centered">
+                    <h2>Internship Paths</h2>
+                    <div class="text">We are especially interested in early-career talent who want hands-on exposure to multidisciplinary work.</div>
+                </div>
+
+                <div class="text-center wow fadeInUp" data-wow-delay="0ms" data-wow-duration="1500ms">
+                    <span class="career-pill">Frontend Developer Intern</span>
+                    <span class="career-pill">Graphic Design Intern</span>
+                    <span class="career-pill">UX/UI Design Intern</span>
+                    <span class="career-pill">Operations Intern</span>
+                    <span class="career-pill">Marketing / Content Intern</span>
+                </div>
+
+                <div class="career-empty-state mt-5 wow fadeInUp" data-wow-delay="100ms" data-wow-duration="1500ms">
+                    <span class="eyebrow">AI-Native Internships</span>
+                    <h3>Coming soon</h3>
+                    <p>We are developing AI-native internship paths as Doable Group expands its workflow, automation, and applied AI capabilities.</p>
+                    <p><span class="career-coming-soon">Planned internship lanes:</span> Prompt Engineering, Agentic Workflow Support, AI Operations, and Workflow Architecture / Automation support.</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="services-page-section background-color-gray-light">
+            <div class="auto-container">
+                <div class="career-empty-state wow fadeInUp" data-wow-delay="0ms" data-wow-duration="1500ms">
+                    <span class="eyebrow">Open Opportunities</span>
+                    <h3>We’re building this page as we grow</h3>
+                    <p>We are currently building our public opportunities page and may not list every role here yet. If you’re interested in working with Doable Group — especially across design, technology, operations, or emerging AI-native internship paths — we’d be glad to hear from you.</p>
+                    <p>This is a polished light-state launch: selective opportunities may be announced on a rolling basis as the company grows.</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="contact-form-section">
+            <div class="auto-container">
+                <div class="career-cta-box wow fadeInUp" data-wow-delay="0ms" data-wow-duration="1500ms">
+                    <h3>Reach out to our careers inbox</h3>
+                    <p>To express interest, email <a href="mailto:careers@doablegroup.com?subject=Careers%20Inquiry">careers@doablegroup.com</a> with your resume, cover letter, and a short note about the kind of work you’d like to do with us.</p>
+                    <div class="career-button-row text-left">
+                        <a href="mailto:careers@doablegroup.com?subject=Careers%20Inquiry" class="theme-btn btn-style-one"><span class="txt">Send your resume &amp; cover letter</span></a>
+                        <a href="mailto:careers@doablegroup.com?subject=Internship%20Interest" class="theme-btn btn-style-three"><span class="txt">Ask about internships</span></a>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <footer class="main-footer">
+            <div class="auto-container">
+                <div class="widgets-section">
+                    <div class="row clearfix">
+                        <div class="footer-column col-lg-4 col-md-6 col-sm-12">
+                            <div class="footer-widget office-widget wow fadeInUp" data-wow-delay="0ms" data-wow-duration="1500ms">
+                                <h4>Location</h4>
+                                <ul class="location-list">
+                                    <li>Germantown, MD, 20874 <br> United States</li>
+                                </ul>
+                                <ul class="social-box">
+                                    <li class="behance">
+                                        <a href="https://www.behance.net/psychobit" aria-label="Behance page" class="icofont-behance"></a>
+                                    </li>
+                                    <li class="instagram">
+                                        <a href="https://www.instagram.com/hod_studioz/" aria-label="instagram page" class="icofont-instagram"></a>
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+
+                        <div class="footer-column col-lg-4 col-md-12 col-sm-12">
+                            <div class="footer-widget logo-widget wow fadeInUp" data-wow-delay="0ms" data-wow-duration="1500ms">
+                                <div class="logo">
+                                    <a href="index.html" id="footer-link">
+                                        <img src="assets/images/logo/footer-logo.png" alt="Doable Group logo" title="" id="footer-image">
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="footer-bottom wow fadeInUp" data-wow-delay="0ms" data-wow-duration="1500ms">
+                <div class="auto-container">
+                    <div class="copyright">Copyright ©
+                        <script type="text/javascript">document.write(new Date().getFullYear());</script>
+                        <span class="text-black">Doable Group</span>.
+                    </div>
+                </div>
+            </div>
+        </footer>
+
+    </div>
+
+    <div class="scroll-to-top scroll-to-target" data-target="html"><span class="icon-arrow-up-circle"></span></div>
+
+    <script src="assets/js/vendor/jquery.js"></script>
+    <script src="assets/js/vendor/popper.min.js"></script>
+    <script src="assets/js/vendor/bootstrap.min.js"></script>
+    <script src="assets/js/vendor/jquery-migrate-3.3.2.min.js"></script>
+    <script src="assets/js/vendor/modernizr-3.11.2.min.js"></script>
+
+    <script src="assets/js/plugins/owl.js"></script>
+    <script src="assets/js/plugins/jquery.mCustomScrollbar.concat.min.js"></script>
+    <script src="assets/js/plugins/jquery.fancybox.js"></script>
+    <script src="assets/js/plugins/wow.js"></script>
+    <script src="assets/js/plugins/mixitup.js"></script>
+    <script src="assets/js/plugins/ajax-mail.js"></script>
+    <script src="assets/js/plugins/jquery.scrollTo.js"></script>
+
+    <script src="assets/js/main.js"></script>
+    <script src="assets/js/logohover.js"></script>
+    <script src="assets/js/logohover2.js"></script>
+    <script src="assets/js/click.js"></script>
+
+    <script>
+        (function(){
+            var s = document.createElement('script');
+            var h = document.querySelector('head') || document.body;
+            s.src = 'https://acsbapp.com/apps/app/dist/js/app.js';
+            s.async = true;
+            s.onload = function(){
+                acsbJS.init({
+                    statementLink: '',
+                    footerHtml: '',
+                    hideMobile: false,
+                    hideTrigger: false,
+                    disableBgProcess: false,
+                    language: 'en',
+                    position: 'left',
+                    leadColor: '#7300ff',
+                    triggerColor: '#7300ff',
+                    triggerRadius: '5px',
+                    triggerPositionX: 'left',
+                    triggerPositionY: 'bottom',
+                    triggerIcon: 'people',
+                    triggerSize: 'medium',
+                    triggerOffsetX: 20,
+                    triggerOffsetY: 20,
+                    mobile: {
+                        triggerSize: 'small',
+                        triggerPositionX: 'left',
+                        triggerPositionY: 'bottom',
+                        triggerOffsetX: 10,
+                        triggerOffsetY: 10,
+                        triggerRadius: '5px'
+                    }
+                });
+            };
+            h.appendChild(s);
+        })();
+    </script>
+
+</body>
+</html>

--- a/careers.html
+++ b/careers.html
@@ -218,122 +218,247 @@
                 <div class="career-hero-copy wow fadeInUp" data-wow-delay="0ms" data-wow-duration="1500ms">
                     <h2>Grow with Doable Group</h2>
                     <p>We’re building across technology, media, design, operations, and modern workflow systems — and we welcome thoughtful people who want to grow with meaningful work.</p>
-                    <div class="career-button-row">
-                        <a href="mailto:careers@doablegroup.com?subject=Careers%20Inquiry" class="theme-btn btn-style-one"><span class="txt">Email careers@doablegroup.com</span></a>
-                        <a href="#opportunity-areas" class="theme-btn btn-style-three"><span class="txt">Explore opportunity areas</span></a>
+                    
+                    <div class="mt-5">
+                        <h3>AI-Native Internships</h3>
+                        <p class="mt-3">We are pioneering AI-native internships designed for the next generation of builders. These roles focus on working alongside advanced AI systems, mastering prompt engineering, and building automated workflows to solve real-world problems.</p>
                     </div>
-                    <p class="career-note">When reaching out, please include your resume, cover letter, and any relevant portfolio or work samples.</p>
                 </div>
             </div>
         </section>
 
-        <section class="services-page-section background-color-gray" id="opportunity-areas">
+        <section class="services-page-section background-color-gray" id="career-paths">
             <div class="auto-container">
                 <div class="sec-title centered">
-                    <h2>Opportunity Areas</h2>
-                    <div class="text">Doable Group is growing intentionally. We may not list every opportunity here yet, but these are the kinds of work we are building toward.</div>
+                    <h2>Career Paths</h2>
+                    <div class="text">Doable Group is growing intentionally. Explore our open roles and internship opportunities below.</div>
                 </div>
 
                 <div class="row clearfix">
-                    <div class="col-lg-6 col-md-6 col-sm-12">
-                        <div class="career-card wow fadeInUp" data-wow-delay="0ms" data-wow-duration="1500ms">
-                            <span class="eyebrow">Software & Product</span>
-                            <h4>Build digital experiences and support product execution</h4>
-                            <ul>
-                                <li>Frontend development</li>
-                                <li>Web and product implementation</li>
-                                <li>QA and technical coordination</li>
-                                <li>Prototype and product support</li>
-                            </ul>
-                        </div>
-                    </div>
-                    <div class="col-lg-6 col-md-6 col-sm-12">
-                        <div class="career-card wow fadeInUp" data-wow-delay="100ms" data-wow-duration="1500ms">
-                            <span class="eyebrow">Design & Creative</span>
-                            <h4>Support brands, interfaces, and creative production</h4>
-                            <ul>
-                                <li>Graphic design</li>
-                                <li>Brand and identity support</li>
-                                <li>UX/UI design</li>
-                                <li>Creative production and asset development</li>
-                            </ul>
-                        </div>
-                    </div>
-                    <div class="col-lg-6 col-md-6 col-sm-12">
-                        <div class="career-card wow fadeInUp" data-wow-delay="0ms" data-wow-duration="1500ms">
-                            <span class="eyebrow">Marketing & Media</span>
-                            <h4>Help shape stories, content, and growth efforts</h4>
-                            <ul>
-                                <li>Marketing and content support</li>
-                                <li>Digital media and audience research</li>
-                                <li>Brand storytelling</li>
-                                <li>Campaign and content coordination</li>
-                            </ul>
-                        </div>
-                    </div>
-                    <div class="col-lg-6 col-md-6 col-sm-12">
-                        <div class="career-card wow fadeInUp" data-wow-delay="100ms" data-wow-duration="1500ms">
-                            <span class="eyebrow">Operations & Admin</span>
-                            <h4>Contribute to coordination, systems, and day-to-day execution</h4>
-                            <ul>
-                                <li>Operations support</li>
-                                <li>Administrative assistance</li>
-                                <li>Business coordination</li>
-                                <li>Workflow and documentation support</li>
-                            </ul>
+                    <div class="col-lg-12 col-md-12 col-sm-12">
+                        <!-- Scrollable Cards Container -->
+                        <div class="career-scroll-container" style="max-height: 600px; overflow-y: auto; padding-right: 15px;">
+                            
+                            <!-- Role 1: Software Developer -->
+                            <div class="career-path-card" style="background: #fff; border-radius: 12px; padding: 30px; margin-bottom: 20px; box-shadow: 0 5px 20px rgba(0,0,0,0.05); cursor: pointer;" onclick="this.classList.toggle('expanded')">
+                                <div class="d-flex justify-content-between align-items-center flex-wrap">
+                                    <div>
+                                        <h4 style="margin-bottom: 10px;">Software Developer</h4>
+                                        <div>
+                                            <span class="career-tag" style="display: inline-block; padding: 4px 12px; background: #f0f0f0; border-radius: 20px; font-size: 12px; margin-right: 8px; color: #333;">Software</span>
+                                            <span class="career-tag" style="display: inline-block; padding: 4px 12px; background: #e3f2fd; border-radius: 20px; font-size: 12px; margin-right: 8px; color: #1565c0;">Full Time</span>
+                                        </div>
+                                    </div>
+                                    <div style="margin-top: 15px; margin-left: auto;">
+                                        <button style="padding: 12px 30px; font-size: 14px; font-weight: 700; color: #999; background: #e0e0e0; border: none; border-radius: 30px; cursor: not-allowed; text-transform: uppercase;" disabled>Closed</button>
+                                    </div>
+                                </div>
+                                <div class="role-details" style="display: none; margin-top: 25px; padding-top: 20px; border-top: 1px solid #eee;">
+                                    <p>We are looking for a skilled Software Developer to join our core product team. You will be responsible for building robust, scalable applications, from our corporate front doors to the headless e-commerce architectures powering our fashion sub-brands.</p>
+                                    <h5 style="margin-top: 15px; font-size: 16px;">Requirements & Responsibilities:</h5>
+                                    <ul style="padding-left: 20px; margin-top: 10px; color: #666; line-height: 1.8;">
+                                        <li>Strong proficiency in modern JavaScript/TypeScript and React/Next.js frameworks.</li>
+                                        <li>Experience building and maintaining Node.js backends and RESTful APIs.</li>
+                                        <li>Familiarity with headless CMS integrations and modern cloud infrastructure (AWS/Vercel).</li>
+                                        <li>Ability to troubleshoot complex integrations and optimize web performance.</li>
+                                    </ul>
+                                </div>
+                            </div>
+
+                            <!-- Role 2: AI Automation Intern -->
+                            <div class="career-path-card" style="background: #fff; border-radius: 12px; padding: 30px; margin-bottom: 20px; box-shadow: 0 5px 20px rgba(0,0,0,0.05); cursor: pointer;" onclick="this.classList.toggle('expanded')">
+                                <div class="d-flex justify-content-between align-items-center flex-wrap">
+                                    <div>
+                                        <h4 style="margin-bottom: 10px;">AI Automation Intern</h4>
+                                        <div>
+                                            <span class="career-tag" style="display: inline-block; padding: 4px 12px; background: #f0f0f0; border-radius: 20px; font-size: 12px; margin-right: 8px; color: #333;">AI</span>
+                                            <span class="career-tag" style="display: inline-block; padding: 4px 12px; background: #f3e5f5; border-radius: 20px; font-size: 12px; margin-right: 8px; color: #6a1b9a;">Internship</span>
+                                        </div>
+                                    </div>
+                                    <div style="margin-top: 15px; margin-left: auto;">
+                                        <button style="padding: 12px 30px; font-size: 14px; font-weight: 700; color: #999; background: #e0e0e0; border: none; border-radius: 30px; cursor: not-allowed; text-transform: uppercase;" disabled>Closed</button>
+                                    </div>
+                                </div>
+                                <div class="role-details" style="display: none; margin-top: 25px; padding-top: 20px; border-top: 1px solid #eee;">
+                                    <p>Join our experimental AI lab to build workflows and prototypes using the latest LLMs. This is a hands-on role where you will learn to orchestrate AI agents for real business use cases, bridging the gap between automation and our daily operations.</p>
+                                    <h5 style="margin-top: 15px; font-size: 16px;">What you'll learn & do:</h5>
+                                    <ul style="padding-left: 20px; margin-top: 10px; color: #666; line-height: 1.8;">
+                                        <li>Master advanced prompt engineering and agentic workflow orchestration.</li>
+                                        <li>Build automated pipelines using tools like n8n, OpenClaw, and custom Python/JS scripts.</li>
+                                        <li>Integrate cutting-edge AI APIs directly into our production operational systems.</li>
+                                        <li>Assist in scaling our internal intelligence and efficiency infrastructure.</li>
+                                    </ul>
+                                </div>
+                            </div>
+
+                            <!-- Role 3: Graphic Designer -->
+                            <div class="career-path-card" style="background: #fff; border-radius: 12px; padding: 30px; margin-bottom: 20px; box-shadow: 0 5px 20px rgba(0,0,0,0.05); cursor: pointer;" onclick="this.classList.toggle('expanded')">
+                                <div class="d-flex justify-content-between align-items-center flex-wrap">
+                                    <div>
+                                        <h4 style="margin-bottom: 10px;">Graphic Designer</h4>
+                                        <div>
+                                            <span class="career-tag" style="display: inline-block; padding: 4px 12px; background: #f0f0f0; border-radius: 20px; font-size: 12px; margin-right: 8px; color: #333;">Design</span>
+                                            <span class="career-tag" style="display: inline-block; padding: 4px 12px; background: #e8f5e9; border-radius: 20px; font-size: 12px; margin-right: 8px; color: #2e7d32;">Part Time</span>
+                                        </div>
+                                    </div>
+                                    <div style="margin-top: 15px; margin-left: auto;">
+                                        <button style="padding: 12px 30px; font-size: 14px; font-weight: 700; color: #999; background: #e0e0e0; border: none; border-radius: 30px; cursor: not-allowed; text-transform: uppercase;" disabled>Closed</button>
+                                    </div>
+                                </div>
+                                <div class="role-details" style="display: none; margin-top: 25px; padding-top: 20px; border-top: 1px solid #eee;">
+                                    <p>Help us shape the visual identity of Doable Group and our evolving apparel sub-brands. You will create assets spanning digital marketing, social media campaigns, and product packaging.</p>
+                                    <h5 style="margin-top: 15px; font-size: 16px;">Requirements & Responsibilities:</h5>
+                                    <ul style="padding-left: 20px; margin-top: 10px; color: #666; line-height: 1.8;">
+                                        <li>Design compelling marketing collateral, apparel graphics, and social media assets.</li>
+                                        <li>Ensure rigorous brand consistency across all physical and digital touchpoints.</li>
+                                        <li>Proficiency in the Adobe Creative Suite (Illustrator, Photoshop, InDesign).</li>
+                                        <li>A strong portfolio demonstrating versatility in modern branding and typography.</li>
+                                    </ul>
+                                </div>
+                            </div>
+
+                            <!-- Role 4: UX/UI Designer -->
+                            <div class="career-path-card" style="background: #fff; border-radius: 12px; padding: 30px; margin-bottom: 20px; box-shadow: 0 5px 20px rgba(0,0,0,0.05); cursor: pointer;" onclick="this.classList.toggle('expanded')">
+                                <div class="d-flex justify-content-between align-items-center flex-wrap">
+                                    <div>
+                                        <h4 style="margin-bottom: 10px;">UX/UI Designer</h4>
+                                        <div>
+                                            <span class="career-tag" style="display: inline-block; padding: 4px 12px; background: #f0f0f0; border-radius: 20px; font-size: 12px; margin-right: 8px; color: #333;">Design</span>
+                                            <span class="career-tag" style="display: inline-block; padding: 4px 12px; background: #e3f2fd; border-radius: 20px; font-size: 12px; margin-right: 8px; color: #1565c0;">Full Time</span>
+                                        </div>
+                                    </div>
+                                    <div style="margin-top: 15px; margin-left: auto;">
+                                        <button style="padding: 12px 30px; font-size: 14px; font-weight: 700; color: #999; background: #e0e0e0; border: none; border-radius: 30px; cursor: not-allowed; text-transform: uppercase;" disabled>Closed</button>
+                                    </div>
+                                </div>
+                                <div class="role-details" style="display: none; margin-top: 25px; padding-top: 20px; border-top: 1px solid #eee;">
+                                    <p>Design seamless and engaging digital experiences across our corporate portals and fashion e-commerce platforms. You will bridge the gap between human interaction and functional interfaces.</p>
+                                    <h5 style="margin-top: 15px; font-size: 16px;">Requirements & Responsibilities:</h5>
+                                    <ul style="padding-left: 20px; margin-top: 10px; color: #666; line-height: 1.8;">
+                                        <li>Lead end-to-end product design from user research and wireframing to high-fidelity prototypes.</li>
+                                        <li>Expertise in Figma and modern prototyping tools.</li>
+                                        <li>Experience designing conversion-optimized e-commerce storefronts.</li>
+                                        <li>Work closely with frontend engineers to ensure pixel-perfect implementation.</li>
+                                    </ul>
+                                </div>
+                            </div>
+
+                            <!-- Role 5: E-commerce Operations Manager -->
+                            <div class="career-path-card" style="background: #fff; border-radius: 12px; padding: 30px; margin-bottom: 20px; box-shadow: 0 5px 20px rgba(0,0,0,0.05); cursor: pointer;" onclick="this.classList.toggle('expanded')">
+                                <div class="d-flex justify-content-between align-items-center flex-wrap">
+                                    <div>
+                                        <h4 style="margin-bottom: 10px;">E-commerce Operations Manager</h4>
+                                        <div>
+                                            <span class="career-tag" style="display: inline-block; padding: 4px 12px; background: #f0f0f0; border-radius: 20px; font-size: 12px; margin-right: 8px; color: #333;">Operations</span>
+                                            <span class="career-tag" style="display: inline-block; padding: 4px 12px; background: #e3f2fd; border-radius: 20px; font-size: 12px; margin-right: 8px; color: #1565c0;">Full Time</span>
+                                        </div>
+                                    </div>
+                                    <div style="margin-top: 15px; margin-left: auto;">
+                                        <button style="padding: 12px 30px; font-size: 14px; font-weight: 700; color: #999; background: #e0e0e0; border: none; border-radius: 30px; cursor: not-allowed; text-transform: uppercase;" disabled>Closed</button>
+                                    </div>
+                                </div>
+                                <div class="role-details" style="display: none; margin-top: 25px; padding-top: 20px; border-top: 1px solid #eee;">
+                                    <p>Oversee the day-to-day digital operations of our fashion sub-brands. You will manage drop campaigns, synchronize inventory data, and maintain our CRM infrastructure.</p>
+                                    <h5 style="margin-top: 15px; font-size: 16px;">Requirements & Responsibilities:</h5>
+                                    <ul style="padding-left: 20px; margin-top: 10px; color: #666; line-height: 1.8;">
+                                        <li>Coordinate inventory management and fulfillment logistics for physical apparel drops.</li>
+                                        <li>Manage SLA tracking and customer data pipelines within our CRM (HubSpot).</li>
+                                        <li>Experience with headless commerce systems and e-commerce platforms (e.g., Shopify, Medusa).</li>
+                                        <li>Strong organizational skills to maintain daily operational workflows.</li>
+                                    </ul>
+                                </div>
+                            </div>
+
+                            <!-- Role 6: Digital Marketing Specialist -->
+                            <div class="career-path-card" style="background: #fff; border-radius: 12px; padding: 30px; margin-bottom: 20px; box-shadow: 0 5px 20px rgba(0,0,0,0.05); cursor: pointer;" onclick="this.classList.toggle('expanded')">
+                                <div class="d-flex justify-content-between align-items-center flex-wrap">
+                                    <div>
+                                        <h4 style="margin-bottom: 10px;">Digital Marketing Specialist</h4>
+                                        <div>
+                                            <span class="career-tag" style="display: inline-block; padding: 4px 12px; background: #f0f0f0; border-radius: 20px; font-size: 12px; margin-right: 8px; color: #333;">Media</span>
+                                            <span class="career-tag" style="display: inline-block; padding: 4px 12px; background: #e3f2fd; border-radius: 20px; font-size: 12px; margin-right: 8px; color: #1565c0;">Full Time</span>
+                                        </div>
+                                    </div>
+                                    <div style="margin-top: 15px; margin-left: auto;">
+                                        <button style="padding: 12px 30px; font-size: 14px; font-weight: 700; color: #999; background: #e0e0e0; border: none; border-radius: 30px; cursor: not-allowed; text-transform: uppercase;" disabled>Closed</button>
+                                    </div>
+                                </div>
+                                <div class="role-details" style="display: none; margin-top: 25px; padding-top: 20px; border-top: 1px solid #eee;">
+                                    <p>Drive growth and audience engagement across Doable Group's portfolio. You will craft compelling brand stories and execute targeted digital campaigns for our apparel lines.</p>
+                                    <h5 style="margin-top: 15px; font-size: 16px;">Requirements & Responsibilities:</h5>
+                                    <ul style="padding-left: 20px; margin-top: 10px; color: #666; line-height: 1.8;">
+                                        <li>Develop and execute multi-channel marketing campaigns (Social, Email, Paid Ads).</li>
+                                        <li>Analyze audience data and engagement metrics to optimize campaign performance.</li>
+                                        <li>Collaborate with the creative team to produce high-impact storytelling assets.</li>
+                                        <li>Experience with SEO/SEM and performance marketing strategies.</li>
+                                    </ul>
+                                </div>
+                            </div>
+
+                            <!-- Role 7: Product & Hardware Designer -->
+                            <div class="career-path-card" style="background: #fff; border-radius: 12px; padding: 30px; margin-bottom: 20px; box-shadow: 0 5px 20px rgba(0,0,0,0.05); cursor: pointer;" onclick="this.classList.toggle('expanded')">
+                                <div class="d-flex justify-content-between align-items-center flex-wrap">
+                                    <div>
+                                        <h4 style="margin-bottom: 10px;">Product & Hardware Designer</h4>
+                                        <div>
+                                            <span class="career-tag" style="display: inline-block; padding: 4px 12px; background: #f0f0f0; border-radius: 20px; font-size: 12px; margin-right: 8px; color: #333;">Design</span>
+                                            <span class="career-tag" style="display: inline-block; padding: 4px 12px; background: #e8f5e9; border-radius: 20px; font-size: 12px; margin-right: 8px; color: #2e7d32;">Part Time</span>
+                                        </div>
+                                    </div>
+                                    <div style="margin-top: 15px; margin-left: auto;">
+                                        <button style="padding: 12px 30px; font-size: 14px; font-weight: 700; color: #999; background: #e0e0e0; border: none; border-radius: 30px; cursor: not-allowed; text-transform: uppercase;" disabled>Closed</button>
+                                    </div>
+                                </div>
+                                <div class="role-details" style="display: none; margin-top: 25px; padding-top: 20px; border-top: 1px solid #eee;">
+                                    <p>Support our physical product initiatives, from conceptual hardware design to detailed apparel tech-packs. You will work closely with leadership to bring physical goods from ideation to production.</p>
+                                    <h5 style="margin-top: 15px; font-size: 16px;">Requirements & Responsibilities:</h5>
+                                    <ul style="padding-left: 20px; margin-top: 10px; color: #666; line-height: 1.8;">
+                                        <li>Develop CAD models, physical prototypes, and technical manufacturing documents.</li>
+                                        <li>Deep understanding of materials, industrial design, and physical production pipelines.</li>
+                                        <li>Assist in supplier communication and quality assurance for physical goods.</li>
+                                        <li>Experience bridging the gap between digital design and real-world manufacturing.</li>
+                                    </ul>
+                                </div>
+                            </div>
+
+                            <!-- Role 8: QA & Technical Coordinator -->
+                            <div class="career-path-card" style="background: #fff; border-radius: 12px; padding: 30px; margin-bottom: 20px; box-shadow: 0 5px 20px rgba(0,0,0,0.05); cursor: pointer;" onclick="this.classList.toggle('expanded')">
+                                <div class="d-flex justify-content-between align-items-center flex-wrap">
+                                    <div>
+                                        <h4 style="margin-bottom: 10px;">QA & Technical Coordinator</h4>
+                                        <div>
+                                            <span class="career-tag" style="display: inline-block; padding: 4px 12px; background: #f0f0f0; border-radius: 20px; font-size: 12px; margin-right: 8px; color: #333;">Software</span>
+                                            <span class="career-tag" style="display: inline-block; padding: 4px 12px; background: #e8f5e9; border-radius: 20px; font-size: 12px; margin-right: 8px; color: #2e7d32;">Part Time</span>
+                                        </div>
+                                    </div>
+                                    <div style="margin-top: 15px; margin-left: auto;">
+                                        <button style="padding: 12px 30px; font-size: 14px; font-weight: 700; color: #999; background: #e0e0e0; border: none; border-radius: 30px; cursor: not-allowed; text-transform: uppercase;" disabled>Closed</button>
+                                    </div>
+                                </div>
+                                <div class="role-details" style="display: none; margin-top: 25px; padding-top: 20px; border-top: 1px solid #eee;">
+                                    <p>Ensure the reliability and functionality of our digital products. You will build test plans, document software behaviors, and coordinate technical rollouts across our portfolio.</p>
+                                    <h5 style="margin-top: 15px; font-size: 16px;">Requirements & Responsibilities:</h5>
+                                    <ul style="padding-left: 20px; margin-top: 10px; color: #666; line-height: 1.8;">
+                                        <li>Execute manual and automated testing on web applications and API integrations.</li>
+                                        <li>Identify, document, and track software defects to resolution.</li>
+                                        <li>Maintain clear technical documentation and coordinate sprint deliverables.</li>
+                                        <li>Strong attention to detail and experience with QA testing frameworks.</li>
+                                    </ul>
+                                </div>
+                            </div>
+
                         </div>
                     </div>
                 </div>
             </div>
         </section>
 
-        <section class="about-section">
-            <div class="auto-container">
-                <div class="sec-title centered">
-                    <h2>Internship Paths</h2>
-                    <div class="text">We are especially interested in early-career talent who want hands-on exposure to multidisciplinary work.</div>
-                </div>
-
-                <div class="text-center wow fadeInUp" data-wow-delay="0ms" data-wow-duration="1500ms">
-                    <span class="career-pill">Frontend Developer Intern</span>
-                    <span class="career-pill">Graphic Design Intern</span>
-                    <span class="career-pill">UX/UI Design Intern</span>
-                    <span class="career-pill">Operations Intern</span>
-                    <span class="career-pill">Marketing / Content Intern</span>
-                </div>
-
-                <div class="career-empty-state mt-5 wow fadeInUp" data-wow-delay="100ms" data-wow-duration="1500ms">
-                    <span class="eyebrow">AI-Native Internships</span>
-                    <h3>Coming soon</h3>
-                    <p>We are developing AI-native internship paths as Doable Group expands its workflow, automation, and applied AI capabilities.</p>
-                    <p><span class="career-coming-soon">Planned internship lanes:</span> Prompt Engineering, Agentic Workflow Support, AI Operations, and Workflow Architecture / Automation support.</p>
-                </div>
-            </div>
-        </section>
-
-        <section class="services-page-section background-color-gray-light">
-            <div class="auto-container">
-                <div class="career-empty-state wow fadeInUp" data-wow-delay="0ms" data-wow-duration="1500ms">
-                    <span class="eyebrow">Open Opportunities</span>
-                    <h3>We’re building this page as we grow</h3>
-                    <p>We are currently building our public opportunities page and may not list every role here yet. If you’re interested in working with Doable Group — especially across design, technology, operations, or emerging AI-native internship paths — we’d be glad to hear from you.</p>
-                    <p>This is a polished light-state launch: selective opportunities may be announced on a rolling basis as the company grows.</p>
-                </div>
-            </div>
-        </section>
-
-        <section class="contact-form-section">
-            <div class="auto-container">
-                <div class="career-cta-box wow fadeInUp" data-wow-delay="0ms" data-wow-duration="1500ms">
-                    <h3>Reach out to our careers inbox</h3>
-                    <p>To express interest, email <a href="mailto:careers@doablegroup.com?subject=Careers%20Inquiry">careers@doablegroup.com</a> with your resume, cover letter, and a short note about the kind of work you’d like to do with us.</p>
-                    <div class="career-button-row text-left">
-                        <a href="mailto:careers@doablegroup.com?subject=Careers%20Inquiry" class="theme-btn btn-style-one"><span class="txt">Send your resume &amp; cover letter</span></a>
-                        <a href="mailto:careers@doablegroup.com?subject=Internship%20Interest" class="theme-btn btn-style-three"><span class="txt">Ask about internships</span></a>
-                    </div>
-                </div>
-            </div>
-        </section>
+        <!-- CSS to handle the expand/collapse behavior -->
+        <style>
+            .career-path-card.expanded .role-details {
+                display: block !important;
+            }
+        </style>
 
         <footer class="main-footer">
             <div class="auto-container">

--- a/contact.html
+++ b/contact.html
@@ -111,12 +111,7 @@
 
                                     <ul class="navigation right-nav clearfix">
                                         <li><a href="about.html">About</a></li>
-
-                                        <!-- <li class="dropdown"><a href="#">Services</a>
-                                            <ul>
-                                                <li><a href="services.html">Our Services</a></li>
-                                            </ul>
-                                        </li> -->
+                                        <li><a href="careers.html">Careers</a></li>
                                         <li class="current"><a href="contact.html">Contact</a></li>
                                     </ul>
 
@@ -268,7 +263,7 @@
                                     <span class="icon icon-envelope-open"></span>
                                 </div>
                                 <ul class="info-list">
-                                    <li><a href="mailto:hello@Obero.co">Contactus@doablegroup.com</a></li>
+                                    <li><a href="mailto:contactus@doablegroup.com">contactus@doablegroup.com</a></li>
                                 </ul>
                             </div>
                         </div> -->
@@ -294,7 +289,7 @@
                                     <span class="icon icon-briefcase"></span>
                                 </div>
                                 <ul class="info-list">
-                                    <li>Send your CV to our email <br> <a href="mailto:career@doablegroup.com">career@doablegroup.com</a></li>
+                                    <li>Send your resume and cover letter to <br> <a href="mailto:careers@doablegroup.com?subject=Careers%20Inquiry">careers@doablegroup.com</a></li>
                                 </ul>
                             </div>
                         </div>

--- a/index.html
+++ b/index.html
@@ -113,12 +113,8 @@
 
                                     <ul class="navigation right-nav clearfix">
                                         <li><a href="about.html" tabindex="4">About</a></li>
-                                        <!-- <li class="dropdown"><a href="#">Services</a>
-                                            <ul>
-                                                <li><a href="services.html">Our Services</a></li>
-                                            </ul>
-                                        </li> -->
-                                        <li><a href="contact.html" tabindex="5">Contact</a></li>
+                                        <li><a href="careers.html" tabindex="5">Careers</a></li>
+                                        <li><a href="contact.html" tabindex="6">Contact</a></li>
                                     </ul>
 
                                 </div>

--- a/services.html
+++ b/services.html
@@ -111,11 +111,7 @@
 
                                     <ul class="navigation right-nav clearfix">
                                         <li><a href="about.html">About</a></li>
-                                        <!-- <li class="dropdown"><a href="#">Services</a>
-                                            <ul>
-                                                <li><a href="services.html">Our Services</a></li>
-                                            </ul>
-                                        </li> -->
+                                        <li><a href="careers.html">Careers</a></li>
                                         <li><a href="contact.html">Contact</a></li>
                                     </ul>
 


### PR DESCRIPTION
## Summary
- add a dedicated careers page
- introduce a polished light-state hiring experience
- add careers navigation across key pages
- route careers CTAs to careers@doablegroup.com with resume + cover letter guidance

## Notes
- AI-native internship lanes are positioned as coming soon
- page is intentionally lightweight rather than a full active job board
